### PR TITLE
checkEqualsNumeric works when given data.frames

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: RUnit
-Version: 0.4.31
-Date: 2015-11-05
+Version: 0.4.32
+Date: 2024-02-09
 Title: R Unit Test Framework
 Author: Matthias Burger <burgerm@users.sourceforge.net>, Klaus
         Juenemann <k.junemann@gmx.net>, Thomas Koenig

--- a/NEWS
+++ b/NEWS
@@ -8,8 +8,11 @@
         *
         **************************************************
 
+Changes in RUnit 0.4.32
+    o	checkEqualsNumeric functions when given two one-column data.frames
+
 Changes in RUnit 0.4.31
-    o   checkEquals and others output optional message on separete line
+    o   checkEquals and others output optional message on separate line
 
 Changes in RUnit 0.4.30
     o   printJUnitProtocol added for JUnit-style output

--- a/R/checkFuncs.r
+++ b/R/checkFuncs.r
@@ -96,6 +96,14 @@ checkEqualsNumeric <- function(target, current, msg="", tolerance = .Machine$dou
   if(.existsTestLogger()) {
     RUnitEnv$.testLogger$incrementCheckNum()
   }
+  ## Fix for R>4.1.2 where as.vector.data.frame returns a list instead of vector
+  if(is.data.frame(target)) {
+  	target <- unlist(as.list(target), use.names=FALSE)
+  }
+  if(is.data.frame(current)) {
+  	current <- unlist(as.list(current), use.names=FALSE)
+  }
+
   ##  R 2.3.0: changed behaviour of all.equal
   ##  strip attributes before comparing current and target
   result <- all.equal.numeric(as.vector(target), as.vector(current), tolerance=tolerance, ...)


### PR DESCRIPTION
As per issue #3, data.frames are converted to vectors using the old logic prior to R 4.1.2.